### PR TITLE
Adding error serializer spec

### DIFF
--- a/lib/jsonapi_errors_handler/error_serializer.rb
+++ b/lib/jsonapi_errors_handler/error_serializer.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module JsonapiErrorsHandler
   class ErrorSerializer
     def initialize(error)
@@ -8,7 +10,7 @@ module JsonapiErrorsHandler
       serializable_hash
     end
 
-    def to_json(payload)
+    def to_json
       to_h.to_json
     end
 

--- a/lib/jsonapi_errors_handler/error_serializer.rb
+++ b/lib/jsonapi_errors_handler/error_serializer.rb
@@ -16,7 +16,7 @@ module JsonapiErrorsHandler
 
     def serializable_hash
       {
-        errors: Array.wrap(error.serializable_hash)
+        errors: [error.serializable_hash]
       }
     end
 

--- a/lib/jsonapi_errors_handler/errors/standard_error.rb
+++ b/lib/jsonapi_errors_handler/errors/standard_error.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_relative '../../keys_stringifier'
 
 module JsonapiErrorsHandler
   module Errors
@@ -7,7 +8,7 @@ module JsonapiErrorsHandler
         @title = title || "Something went wrong"
         @detail = detail || "We encountered unexpected error, but our developers had been already notified about it"
         @status = status || 500
-        @source = KeysStringifier.(source)
+        @source = ::KeysStringifier.(source)
       end
 
       def to_h
@@ -28,15 +29,6 @@ module JsonapiErrorsHandler
       end
 
       attr_reader :title, :detail, :status, :source
-    end
-  end
-end
-
-class KeysStringifier
-  def self.call(hash)
-    hash.reduce({}) do |h, (k,v)|
-      new_val = v.is_a?(Hash) ? self.call(v) : v
-      h.merge({k.to_s => new_val})
     end
   end
 end

--- a/lib/jsonapi_errors_handler/errors/standard_error.rb
+++ b/lib/jsonapi_errors_handler/errors/standard_error.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative '../../keys_stringifier'
+require 'jsonapi_errors_handler/keys_stringifier'
 
 module JsonapiErrorsHandler
   module Errors
@@ -8,7 +8,7 @@ module JsonapiErrorsHandler
         @title = title || "Something went wrong"
         @detail = detail || "We encountered unexpected error, but our developers had been already notified about it"
         @status = status || 500
-        @source = ::KeysStringifier.(source)
+        @source = KeysStringifier.(source)
       end
 
       def to_h

--- a/lib/jsonapi_errors_handler/errors/standard_error.rb
+++ b/lib/jsonapi_errors_handler/errors/standard_error.rb
@@ -7,7 +7,7 @@ module JsonapiErrorsHandler
         @title = title || "Something went wrong"
         @detail = detail || "We encountered unexpected error, but our developers had been already notified about it"
         @status = status || 500
-        @source = source.deep_stringify_keys
+        @source = KeysStringifier.(source)
       end
 
       def to_h
@@ -28,6 +28,15 @@ module JsonapiErrorsHandler
       end
 
       attr_reader :title, :detail, :status, :source
+    end
+  end
+end
+
+class KeysStringifier
+  def self.call(hash)
+    hash.reduce({}) do |h, (k,v)|
+      new_val = v.is_a?(Hash) ? self.call(v) : v
+      h.merge({k.to_s => new_val})
     end
   end
 end

--- a/lib/jsonapi_errors_handler/keys_stringifier.rb
+++ b/lib/jsonapi_errors_handler/keys_stringifier.rb
@@ -1,0 +1,10 @@
+module JsonapiErrorsHandler
+  class KeysStringifier
+    def self.call(hash)
+      hash.reduce({}) do |h, (k,v)|
+        new_val = v.is_a?(Hash) ? self.call(v) : v
+        h.merge({k.to_s => new_val})
+      end
+    end
+  end
+end

--- a/lib/keys_stringifier.rb
+++ b/lib/keys_stringifier.rb
@@ -1,8 +1,0 @@
-class KeysStringifier
-  def self.call(hash)
-    hash.reduce({}) do |h, (k,v)|
-      new_val = v.is_a?(Hash) ? self.call(v) : v
-      h.merge({k.to_s => new_val})
-    end
-  end
-end

--- a/lib/keys_stringifier.rb
+++ b/lib/keys_stringifier.rb
@@ -1,0 +1,8 @@
+class KeysStringifier
+  def self.call(hash)
+    hash.reduce({}) do |h, (k,v)|
+      new_val = v.is_a?(Hash) ? self.call(v) : v
+      h.merge({k.to_s => new_val})
+    end
+  end
+end

--- a/spec/error_serializer_spec.rb
+++ b/spec/error_serializer_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe JsonapiErrorsHandler::ErrorSerializer do
+  let(:error) { JsonapiErrorsHandler::Errors::StandardError.new }
+  let(:subject) { JsonapiErrorsHandler::ErrorSerializer.new(error) }
+
+  describe '#to_h' do
+    it 'returns error in hash format' do
+      result = subject.to_h
+      expect(result[:errors]).to eq [{status: 500,
+                                      title: 'Something went wrong',
+                                      detail: 'We encountered unexpected error, but our developers had been already notified about it',
+                                      source: {}}]
+    end
+  end
+
+  describe '#to_json' do
+    it 'converts hash into json' do
+      expect(subject.to_json).to eq "{\"errors\":[{\"status\":500,\"title\":\"Something went wrong\",\"detail\":\"We encountered unexpected error, but our developers had been already notified about it\",\"source\":{}}]}"
+    end
+  end
+end


### PR DESCRIPTION
This PR including:
- Adding spec for ErrorSerializer which is mentioned in #1 
- Fix issue #5 
- Use `[]` instead of `Array.wrap`, require `json` before using it.
- Remove `payload` argument from method `to_json`. Because I have not seen where will use it.
