### PR TITLE
Add logging mechanizm

### DIFF
--- a/lib/jsonapi_errors_handler.rb
+++ b/lib/jsonapi_errors_handler.rb
@@ -16,6 +16,7 @@ module JsonapiErrorsHandler
 
       def handle_error(e)
         mapped = map_error(e)
+        log_error(e) if respond_to?(:log_error) && !mapped
         mapped ||= ::JsonapiErrorsHandler::Errors::StandardError.new
         render_error(mapped)
       end


### PR DESCRIPTION
Whenever user implements the `log_error` method in the including class
Gem calls it for all unmapped errors allowing custom error logging and
email notifications to be sent.

Resolves: #13